### PR TITLE
[iOS 10] Make the WebView opaque to prevent black bars

### DIFF
--- a/Source/FTWebPageView.m
+++ b/Source/FTWebPageView.m
@@ -49,6 +49,7 @@ static NSString *_defaultApplicationScheme = nil;
   if (_webView == nil) {
     _webView = [[self.webViewClass alloc] initWithFrame:self.bounds];
     _webView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+    _webView.opaque = NO;
     _webView.delegate = self;
     // This has to be enabled so that the webview automatically resizes the
     // content after orientation changes.


### PR DESCRIPTION
During orientation changes the WebView doesn't seem to redraw it's background properly when it's not explicitly set to not opaque.
